### PR TITLE
Remove duplicate definition by changing header file to declarations

### DIFF
--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -40,9 +40,10 @@ void PulseMeterSensor::loop() {
   this->get_ = temp;
 
   // Print all the logging information
+  ESP_LOGD(TAG, "LOG: %u -> %u", this->last_log_index_, this->logging_index_);
   for (; this->last_log_index_ != this->logging_index_; this->last_log_index_ = (this->last_log_index_ + 1) % 100) {
     const auto &log = this->logging_[this->last_log_index_];
-    ESP_LOGD(TAG, "ISR: %u %u %u %u %u %u", log.time_, log.pin_, log.last_pin_val_, log.filter_length_,
+    ESP_LOGV(TAG, "ISR: %u %u %u %u %u %u", log.time_, log.pin_, log.last_pin_val_, log.filter_length_,
              log.start_in_pulse_, log.end_in_pulse_);
   }
 

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -15,12 +15,12 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
     FILTER_PULSE,
   };
 
-  void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
-  void set_filter_us(uint32_t filter) { this->filter_us_ = filter; }
-  void set_timeout_us(uint32_t timeout) { this->timeout_us_ = timeout; }
-  void set_total_sensor(sensor::Sensor *sensor) { this->total_sensor_ = sensor; }
-  void set_filter_mode(InternalFilterMode mode) { this->filter_mode_ = mode; }
-  void set_total_pulses(uint32_t pulses) { this->total_pulses_ = pulses; }
+  void set_pin(InternalGPIOPin *pin);
+  void set_filter_us(uint32_t filter);
+  void set_timeout_us(uint32_t timeout);
+  void set_total_sensor(sensor::Sensor *sensor);
+  void set_filter_mode(InternalFilterMode mode);
+  void set_total_pulses(uint32_t pulses);
 
   void setup() override;
   void loop() override;


### PR DESCRIPTION
# What does this implement/fix?

The pulse meter did not compile with "redefinition" errors. Changed the definition to declaration in header file, as it is defined in cpp file anyway.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other